### PR TITLE
[AI][JULES] Add /me endpoint to retrieve your information

### DIFF
--- a/src/main/java/com/psicoclinic/psicoapp/controller/UserController.java
+++ b/src/main/java/com/psicoclinic/psicoapp/controller/UserController.java
@@ -1,0 +1,22 @@
+package com.psicoclinic.psicoapp.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping; // Added
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.psicoclinic.psicoapp.dto.UserDTO; // Added import
+
+@RestController
+@RequestMapping("") // Changed from "/users" to "" to make the endpoint /me
+public class UserController {
+
+    @GetMapping("/me")
+    public UserDTO getUserInfo(@AuthenticationPrincipal Jwt principal) {
+        String id = principal.getSubject(); // 'sub' claim is typically used for user ID
+        String email = principal.getClaimAsString("email");
+        String name = principal.getClaimAsString("name"); // Or "preferred_username", "given_name", etc.
+
+        return new UserDTO(id, email, name);
+    }
+}

--- a/src/main/java/com/psicoclinic/psicoapp/dto/UserDTO.java
+++ b/src/main/java/com/psicoclinic/psicoapp/dto/UserDTO.java
@@ -1,0 +1,39 @@
+package com.psicoclinic.psicoapp.dto;
+
+public class UserDTO {
+    private String id;
+    private String email;
+    private String name;
+
+    public UserDTO(String id, String email, String name) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+    }
+
+    // Getters
+    public String getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    // Setters (optional, depending on use case)
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/test/java/com/psicoclinic/psicoapp/controller/UserControllerTest.java
+++ b/src/test/java/com/psicoclinic/psicoapp/controller/UserControllerTest.java
@@ -1,0 +1,44 @@
+package com.psicoclinic.psicoapp.controller;
+
+import com.psicoclinic.psicoapp.dto.UserDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(UserController.class)
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void shouldReturnUserInfoWhenAuthenticated() throws Exception {
+        // 1. Mock Jwt and its claims
+        Jwt mockJwt = mock(Jwt.class);
+        when(mockJwt.getSubject()).thenReturn("testUserId");
+        when(mockJwt.getClaimAsString("email")).thenReturn("test@example.com");
+        when(mockJwt.getClaimAsString("name")).thenReturn("Test User");
+
+        // 2. Perform GET request to /me with the mocked Jwt principal
+        mockMvc.perform(get("/me")
+                        .with(jwt().jwt(mockJwt))) // Use jwt() post-processor
+                // 3. Verify HTTP 200 OK status
+                .andExpect(status().isOk())
+                // 4. Verify response body
+                .andExpect(jsonPath("$.id").value("testUserId"))
+                .andExpect(jsonPath("$.email").value("test@example.com"))
+                .andExpect(jsonPath("$.name").value("Test User"));
+    }
+}


### PR DESCRIPTION
This commit introduces a new GET endpoint `/me` that allows authenticated users to retrieve their own information (ID, email, and name) from the Keycloak JWT.

Changes include:
- Created `UserController` to handle user-related requests.
- Implemented the `/me` endpoint in `UserController`, which extracts your details from the `Jwt` principal.
- Created `UserDTO` to represent your information returned by the endpoint.
- Added unit tests for the `/me` endpoint in `UserControllerTest` using `MockMvc` and Spring Security test support to mock the `Jwt` principal and verify the response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an authenticated endpoint to retrieve the current user's ID, email, and name.
- **Tests**
  - Introduced tests to verify correct user information is returned for authenticated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->